### PR TITLE
Fixed grep and awk commands.

### DIFF
--- a/console_completion.sh
+++ b/console_completion.sh
@@ -59,10 +59,10 @@ _complete_sf2_app_console() {
 
     if [[ ${COMP_CWORD} == 1 ]] ; then
         # No command found, return the list of available commands
-        cmds=` ${console} --no-ansi | sed -n -e '/^Available commands/,//p' | grep '^ ' | awk '{ print $2 }'  `
+        cmds=` ${console}  --no-ansi | sed -n -e '/^Available commands/,//p' | grep -n '^ ' | sed -e 's/^ \+//' | awk '{ print $2 }'`
     else
         # Commands found, parse options
-        cmds=` ${console} ${COMP_WORDS[1]} --no-ansi --help | sed -n -e '/^Options/,/^$/p' | grep '^ ' | awk '{ print $1 }' `
+        cmds=` ${console} ${COMP_WORDS[1]} --no-ansi --help | sed -n -e '/^Options/,/^$/p' | grep -n '^ ' | sed -e 's/^ \+//' | awk '{ print $2 }'`
     fi
 
     COMPREPLY=( $(compgen -W "${cmds}" -- ${cur}) )

--- a/console_completion.sh
+++ b/console_completion.sh
@@ -3,21 +3,21 @@
 # Symfony2 App/Console autocompletion (commands and arguments only)
 # Copyright (c) 2014, Joshua Thijssen
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-# 
+#
 # * Redistributions of source code must retain the above copyright notice, this
 #   list of conditions and the following disclaimer.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice, this
 #   list of conditions and the following disclaimer in the documentation and/or
 #   other materials provided with the distribution.
-# 
+#
 # * Neither the name of the {organization} nor the names of its
 #   contributors may be used to endorse or promote products derived from
 #   this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -29,7 +29,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-# 
+#
 # Usable for both bash and zsh (probably)
 #
 # Usage:
@@ -59,7 +59,7 @@ _complete_sf2_app_console() {
 
     if [[ ${COMP_CWORD} == 1 ]] ; then
         # No command found, return the list of available commands
-        cmds=` ${console} --no-ansi | sed -n -e '/^Available commands/,//p' | grep '^  ' | awk '{ print $1 }'  `
+        cmds=` ${console} --no-ansi | sed -n -e '/^Available commands/,//p' | grep '^ ' | awk '{ print $2 }'  `
     else
         # Commands found, parse options
         cmds=` ${console} ${COMP_WORDS[1]} --no-ansi --help | sed -n -e '/^Options/,/^$/p' | grep '^ ' | awk '{ print $1 }' `


### PR DESCRIPTION
I noticed that due to differences between wat the grep and awk commands were assuming, and what the actual output from app/console was, the autocomplete didn't complete anything. This change fixes that.

I don't know if it's environment specific. This fix worked for me in a Vagrant box with Ubuntu 14.04, php 5.5.13, and a Symfony install that identifies itself as 2.7.0-DEV.
